### PR TITLE
Split make rules for independent Lua/Python build and install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,37 +2,48 @@
 
 PROFILE ?= release
 
+.PHONY: default
+default: install-lua
+
+.PHONY: install
+install: install-lua
+
 .PHONY: all
-all: all-rust links
+all: install-all
+
+.PHONY: install-all
+install-all: install-lua install-python
 
 .PHONY: all-rust
-all-rust: lua_lib python_lib
+all-rust: lib-lua lib-python
 
+RUST_SOURCES = Cargo.lock src/lib.rs
 CARGO_FLAGS = $(and $(PROFILE:debug=),--$(PROFILE))
 
-.PHONY: lua_lib
-lua_lib: target-lua/$(PROFILE)/libvim_commonmark.so
+.PHONY: lib-lua
+lib-lua: target-lua/$(PROFILE)/libvim_commonmark.so
 
-RUST_SOURCES = Cargo.lock $(wildcard src/*.rs)
-
-target-lua/$(PROFILE)/libvim_commonmark.so: $(RUST_SOURCES)
+target-lua/$(PROFILE)/libvim_commonmark.so: $(RUST_SOURCES) src/lua.rs
 	export LUA_INC=/usr/include/luajit-2.0/
 	export LUA_LIB=/usr/lib LUA_LIB_NAME=luajit-5.1
 	export LUA_LINK=dynamic
 	cargo build --no-default-features --features lua --target-dir target-lua $(CARGO_FLAGS)
 
-.PHONY: python_lib
-python_lib: target-python/$(PROFILE)/libvim_commonmark.so
+.PHONY: lib-python
+lib-python: target-python/$(PROFILE)/libvim_commonmark.so
 
-target-python/$(PROFILE)/libvim_commonmark.so: $(RUST_SOURCES)
+target-python/$(PROFILE)/libvim_commonmark.so: $(RUST_SOURCES) src/python.rs
 	cargo build --no-default-features --features python --target-dir target-python $(CARGO_FLAGS)
 
-.PHONY: links
-links: lua/libvim_commonmark.so python3/libvim_commonmark.so
+.PHONY: install-lua
+install-lua: lua/libvim_commonmark.so
 
 lua/libvim_commonmark.so: target-lua/$(PROFILE)/libvim_commonmark.so
 	mkdir -p $(@D)
 	ln -sf ../$< $@
+
+.PHONY: install-python
+install-python: python3/libvim_commonmark.so
 
 python3/libvim_commonmark.so: target-python/$(PROFILE)/libvim_commonmark.so
 	mkdir -p $(@D)
@@ -47,4 +58,3 @@ test-rust:
 	export LUA_LIB=/usr/lib LUA_LIB_NAME=luajit-5.1
 	export LUA_LINK=dynamic
 	cargo test --no-default-features --features lua --target-dir target-lua $(CARGO_FLAGS)
-


### PR DESCRIPTION
Building the Python module requires Rust nightly, which I only have on some of my machines. This makes the default build and install only the Lua module, but the Python can be build to:

```sh
# Default
$ make install-lua

# Only build (useful for `entr` etc.)
$ make lib-lua

# Build and install Python module
$ make install-python

# Build and install both
$ make install-all
```

And so on. You get the point.